### PR TITLE
feat: Add primitive win logic for team who first reaches 60 points

### DIFF
--- a/SharedUI/Sources/Screens/Game/GameView.swift
+++ b/SharedUI/Sources/Screens/Game/GameView.swift
@@ -123,8 +123,11 @@ private extension GameView {
     func getGameFooterView() -> some View {
         switch viewModel.gamePhase {
         case .activityPicking, .roundEvaluation:
-            ProgressView(teams: $viewModel.teams)
-                .frame(maxHeight: 120)
+            ProgressView(
+                gameMaxPoints: GameViewModel.Constants.winPointsThreshold,
+                teams: $viewModel.teams
+            )
+            .frame(maxHeight: 120)
         case .guessing:
             ActionButton(
                 onTap: {

--- a/SharedUI/Sources/Screens/Game/GameViewModel.swift
+++ b/SharedUI/Sources/Screens/Game/GameViewModel.swift
@@ -17,34 +17,47 @@ public final class GameViewModel: ObservableObject {
     }
 
     @Published var currentTurnTeam: Team
-    @Published var earnedPointsThisTurn: Int = .zero
+    @Published var earnedPointsThisTurn: Int = .zero {
+        didSet {
+            if currentTurnTeam.score + earnedPointsThisTurn >= Constants.winPointsThreshold {
+                eventSubject.send(.winnerTeam(currentTurnTeam))
+            }
+        }
+    }
     @Published var gamePhase: GamePhase = .activityPicking
     @Published var currentWord: String?
     @Published var remainingTime: Int = 60
 
+    private let eventSubject = PassthroughSubject<ViewAction, Never>()
     private var selectedActivity: ActivityType?
     private var currentDifficulty: WordDifficulty = .baby
     private var timer: AnyCancellable?
     private let teamService: TeamService
     private let gameService: GameServicing
-
     private let wordService: WordProviding
+    private let colors = [
+        Color.blueLight,
+        Color.carmineRed,
+        Color.teamOrange,
+        Color.teamPurple,
+        Color.yellowBorder,
+        Color.textInputActive
+    ]
 
     @Published  var game: Game
-
     @Published var teams: [Team]
-    private let colors = [
-            Color.blueLight,
-            Color.carmineRed,
-            Color.teamOrange,
-            Color.teamPurple,
-            Color.yellowBorder,
-            Color.textInputActive
-    ]
 
     var currentTeamColor: Color {
         let indexOfCurrentTeam = teams.firstIndex(where: { $0.id == currentTurnTeam.id }) ?? .zero
         return colors[indexOfCurrentTeam]
+    }
+
+    enum Constants {
+        static let winPointsThreshold: Int = 60
+    }
+
+    public enum ViewAction {
+        case winnerTeam(Team)
     }
 
     public init(

--- a/SharedUI/Sources/Screens/Game/ProgressView.swift
+++ b/SharedUI/Sources/Screens/Game/ProgressView.swift
@@ -1,6 +1,6 @@
 //
 //  SwiftUIView.swift
-//  
+//
 //
 //  Created by Raul Batista on 09.03.2024.
 //
@@ -8,15 +8,9 @@
 import Core
 import SwiftUI
 
-//struct ProgressViewContainer: View {
-//    var body: some View {
-//        ProgressView(teams: [
-//
-//        ])
-//    }
-//}
-
 struct ProgressView: View {
+    let gameMaxPoints: Int
+
     @Binding var teams: [Team]
     private let colors = [
         Color.blueLight,
@@ -30,11 +24,11 @@ struct ProgressView: View {
     var body: some View {
         GeometryReader { proxy in
             VStack {
-                ForEach(teams.indices) { teamIndex in
+                ForEach(0..<teams.count, id: \.self) { teamIndex in
                     progressBar(
                         proxy: proxy,
                         progressBarColor: colors[teamIndex],
-                        progress: Double(teams[teamIndex].score) / 60
+                        progress: Double(teams[teamIndex].score) / CGFloat(gameMaxPoints)
                     )
                 }
             }
@@ -70,36 +64,39 @@ private extension ProgressView {
 }
 
 #Preview {
-    ProgressView(teams: .constant([
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokani",
-            avatarId: Avatar.avatarAlert.rawValue
-        ),
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokanice",
-            avatarId: Avatar.avatarCash.rawValue
-        ),
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokanice",
-            avatarId: Avatar.avatarCash.rawValue
-        ),
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokanice",
-            avatarId: Avatar.avatarCash.rawValue
-        ),
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokanice",
-            avatarId: Avatar.avatarCash.rawValue
-        ),
-        Team(
-            id: UUID().uuidString,
-            teamName: "Klokanice",
-            avatarId: Avatar.avatarCash.rawValue
-        )
-    ]))
+    ProgressView(
+        gameMaxPoints: 60,
+        teams: .constant([
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokani",
+                avatarId: Avatar.avatarAlert.rawValue
+            ),
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokanice",
+                avatarId: Avatar.avatarCash.rawValue
+            ),
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokanice",
+                avatarId: Avatar.avatarCash.rawValue
+            ),
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokanice",
+                avatarId: Avatar.avatarCash.rawValue
+            ),
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokanice",
+                avatarId: Avatar.avatarCash.rawValue
+            ),
+            Team(
+                id: UUID().uuidString,
+                teamName: "Klokanice",
+                avatarId: Avatar.avatarCash.rawValue
+            )
+        ])
+    )
 }


### PR DESCRIPTION
This PR introduces the primitive win logic for the team who first reaches 60 points. The event should navigate to winner screen which is not implemented yet.

Also we cleanup some commented code and fix minor warning